### PR TITLE
testjoin not working well with adcli join

### DIFF
--- a/manifests/join.pp
+++ b/manifests/join.pp
@@ -66,7 +66,7 @@ ${ad_join_computer_name_command} --login-user=\'${ad_join_username}\' --domain=\
 --stdin-password --verbose ${ad_join_os_command} ${ad_join_os_version_command} ${ad_join_os_service_pack_command} \
 ${ad_join_service_names_command}",
       logoutput => true,
-      unless    => "/usr/sbin/adcli testjoin -D ${ad_domain}",
+      creates   => '/etc/krb5.keytab',
     }
   }
 }


### PR DESCRIPTION
testjoin works well with keytabs created with "net". When creating a computer with "--computer-name=mycomputer", no principal "MYCOMPUTER@REALM" is created.
Testjoin needs this principal, because AD always responde uppercase, and Linux is casesensitive.

Revert to old way.